### PR TITLE
Gradle dependency path incorrect

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,6 @@ repositories {
 }
 
 dependencies {
-    compile fg.deobf('curse.maven:obfuscate:<curseforge_file_id>')
+    compile fg.deobf('curse.maven:obfuscate-289380:<curseforge_file_id>')
 }
 ```


### PR DESCRIPTION
The dependency is incorrect, it should be `curse.maven:<name>-<project-id>:<file-id>`
The project id was missing